### PR TITLE
fix: removed hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       // - https://revealjs.com/initialization/
       // - https://revealjs.com/config/
       Reveal.initialize({
-        hash: true,
+        // hash: true,
 
         // Learn about plugins: https://revealjs.com/plugins/
         plugins: [RevealMarkdown, RevealHighlight, RevealNotes],


### PR DESCRIPTION
I don't think the multiplex plugin can work if the Reveal `hash` is used in the url.